### PR TITLE
[AMQ-9366] Fix kahadb test failing with JDK 21 due to deprecated SecurityManager

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBPersistenceAdapter.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBPersistenceAdapter.java
@@ -44,6 +44,7 @@ import org.apache.activemq.store.TransactionStore;
 import org.apache.activemq.store.kahadb.data.KahaLocalTransactionId;
 import org.apache.activemq.store.kahadb.data.KahaTransactionInfo;
 import org.apache.activemq.store.kahadb.data.KahaXATransactionId;
+import org.apache.activemq.store.kahadb.disk.journal.DataFileFactory;
 import org.apache.activemq.store.kahadb.disk.journal.Journal.JournalDiskSyncStrategy;
 import org.apache.activemq.usage.SystemUsage;
 import org.apache.activemq.util.ServiceStopper;
@@ -595,6 +596,10 @@ public class KahaDBPersistenceAdapter extends LockableServiceSupport implements 
 
     public void setArchiveDataLogs(boolean archiveDataLogs) {
         letter.setArchiveDataLogs(archiveDataLogs);
+    }
+
+    public void setDataFileFactory(DataFileFactory dataFileFactory) {
+        letter.setDataFileFactory(dataFileFactory);
     }
 
     public File getDirectoryArchive() {

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -93,6 +93,7 @@ import org.apache.activemq.store.kahadb.disk.index.BTreeIndex;
 import org.apache.activemq.store.kahadb.disk.index.BTreeVisitor;
 import org.apache.activemq.store.kahadb.disk.index.ListIndex;
 import org.apache.activemq.store.kahadb.disk.journal.DataFile;
+import org.apache.activemq.store.kahadb.disk.journal.DataFileFactory;
 import org.apache.activemq.store.kahadb.disk.journal.Journal;
 import org.apache.activemq.store.kahadb.disk.journal.Journal.JournalDiskSyncStrategy;
 import org.apache.activemq.store.kahadb.disk.journal.Location;
@@ -266,6 +267,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
 
     protected JournalDiskSyncStrategy journalDiskSyncStrategy = JournalDiskSyncStrategy.ALWAYS;
     protected boolean archiveDataLogs;
+    protected DataFileFactory dataFileFactory;
     protected File directoryArchive;
     protected AtomicLong journalSize = new AtomicLong(0);
     long journalDiskSyncInterval = 1000;
@@ -3421,6 +3423,9 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
             IOHelper.mkdirs(getDirectoryArchive());
             manager.setDirectoryArchive(getDirectoryArchive());
         }
+        if (getDataFileFactory() != null) {
+            manager.setDataFileFactory(getDataFileFactory());
+        }
         return manager;
     }
 
@@ -3651,6 +3656,14 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
      */
     public void setArchiveDataLogs(boolean archiveDataLogs) {
         this.archiveDataLogs = archiveDataLogs;
+    }
+
+    public DataFileFactory getDataFileFactory() {
+        return this.dataFileFactory;
+    }
+
+    public void  setDataFileFactory(DataFileFactory dataFileFactory) {
+        this.dataFileFactory = dataFileFactory;
     }
 
     /**

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/DataFileFactory.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/DataFileFactory.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.kahadb.disk.journal;
+
+import java.io.File;
+
+public interface DataFileFactory {
+    DataFile create(File file, int number);
+}

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/DefaultDataFileFactory.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/DefaultDataFileFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.kahadb.disk.journal;
+
+import java.io.File;
+
+public class DefaultDataFileFactory implements DataFileFactory {
+    @Override
+    public DataFile create(File file, int number) {
+        return new DataFile(file, number);
+    }
+}

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/TestDataFileFactory.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/journal/TestDataFileFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.kahadb.disk.journal;
+
+import org.apache.activemq.util.IOHelper;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.activemq.store.kahadb.disk.journal.Journal.DEFAULT_ARCHIVE_DIRECTORY;
+
+public class TestDataFileFactory implements DataFileFactory {
+    @Override
+    public DataFile create(File file, int number) {
+        return new TestDataFile(file, number);
+    }
+
+    public class TestDataFile extends DataFile {
+
+        TestDataFile(File file, int number) {
+            super(file, number);
+        }
+
+        @Override
+        public synchronized void move(File targetDirectory) throws IOException {
+            if (targetDirectory.getName().contains(DEFAULT_ARCHIVE_DIRECTORY) && this.dataFileId > 5) {
+                throw new SecurityException("No Perms to write to archive times:" + this.dataFileId);
+            }
+            IOHelper.moveFile(file, targetDirectory);
+        }
+    }
+}
+


### PR DESCRIPTION
* This change fixed kahadb test failing with JDK 21 due to deprecated SecurityManager.
